### PR TITLE
Tree chart fixes and Lock common filters

### DIFF
--- a/src/main/java/org/hpccsystems/dashboard/common/Queries.java
+++ b/src/main/java/org/hpccsystems/dashboard/common/Queries.java
@@ -9,7 +9,6 @@ public class Queries {
     private Queries() {
     }
     
-    public static final String INSERT_DASHBOARD = "INSERT INTO dashboard_details(dashboard_name,user_id,application_Id,last_updated_date,column_count,sequence,source_id,visibility,common_filter) VALUES(?,?,?,?,?,?,?,?,?)";
     public static final String DELETE_DASHBOARD_WIDGETS = "delete from widget_details where dashboard_id=?";
     public static final String DELETE_WIDGETS = "delete from widget_details where widget_id=?";
     public static final String DELETE_DASHBOARD = "delete from dashboard_details where dashboard_id=? and user_id =? ";    
@@ -24,7 +23,7 @@ public class Queries {
     public static final String RETRIEVE_DASHBOARD_DETAILS = "select * from dashboard_details where application_id = ";
     public static final String DASHBOARD_IN_CLAUSE = " and dashboard_id in ";
     public static final String UPDATE_SIDEBAR_DETAILS = "update dashboard_details set sequence=? where dashboard_id=?";
-    public static final String UPDATE_DASHBOARD =  "update dashboard_details set dashboard_name=?,column_count=?,source_id=?,last_updated_date=?,visibility=?,common_filter=?,show_localfilter=? where dashboard_id=?";
+    public static final String UPDATE_DASHBOARD =  "update dashboard_details set dashboard_name=?,column_count=?,source_id=?,last_updated_date=?,visibility=?,common_filter=?,show_localfilter=?,lock_commonfilter=? where dashboard_id=?";
     public static final String UPDATE_WIDGET_SEQUENCE = "update widget_details set column_identifier=?,widget_sequence=? where widget_id=? and dashboard_id=?";
     public static final String ADD_CHART_DATA = "update widget_details set widget_state=?, chart_type=?  where widget_id=?";
     public static final String CLEAR_CHART_DATA = "update widget_details set widget_name=?, widget_state=?,chart_type=?,chart_data=?  where widget_id=?";
@@ -38,7 +37,7 @@ public class Queries {
     public static final String SELECT_GROUP="select * from acl_public where dashboard_id = ?";
     public static final String DELETE_GROUP="delete from acl_public where dashboard_id=? and group_code in(?)";
     public static final String GET_PRIVATE_DASHBOARDS = "SELECT * FROM dashboard_details WHERE user_id=? AND application_id=? order by sequence";
-    public static final String GET_ROLE_BASED_DASHBOARDS = "SELECT a.role,d.dashboard_id,d.application_id,d.dashboard_name,d.column_count,d.source_id,d.visibility,d.last_updated_date,d.common_filter,d.show_localfilter FROM acl_public AS a JOIN dashboard_details AS d ON a.dashboard_id = d.dashboard_id AND a.group_code in ";
+    public static final String GET_ROLE_BASED_DASHBOARDS = "SELECT a.role,d.dashboard_id,d.application_id,d.dashboard_name,d.column_count,d.source_id,d.visibility,d.last_updated_date,d.common_filter,d.show_localfilter,d.lock_commonfilter FROM acl_public AS a JOIN dashboard_details AS d ON a.dashboard_id = d.dashboard_id AND a.group_code in ";
     public static final String GET_ALL_DASHBOARD = "SELECT * FROM dashboard_details where application_id=? order by sequence";
     public static final String GET_DASHBOARD = "SELECT * FROM dashboard_details WHERE dashboard_id=?";
     public static final String DELETE_ACL_PUBLIC = "delete from acl_public where dashboard_id=?";

--- a/src/main/java/org/hpccsystems/dashboard/controller/DashboardConfigurationController.java
+++ b/src/main/java/org/hpccsystems/dashboard/controller/DashboardConfigurationController.java
@@ -49,6 +49,8 @@ public class DashboardConfigurationController extends SelectorComposer<Component
     @Wire
     Checkbox commonFiltersCheckbox;
     @Wire
+    Checkbox lockCfCheckbox;
+    @Wire
     Checkbox localFiltersCheckbox;
     @Wire
     Hbox commonFilterHbox;
@@ -91,6 +93,7 @@ public class DashboardConfigurationController extends SelectorComposer<Component
             
             if(dashboard.getHasCommonFilter()){
                 commonFiltersCheckbox.setChecked(true);
+                lockCfCheckbox.setChecked(dashboard.isLockCommonFilter());
                 isCommonFiltersEnabled = true;
             }
             
@@ -137,6 +140,7 @@ public class DashboardConfigurationController extends SelectorComposer<Component
             //Changing configuration of existing board            
             dashboard.setName(nameTextbox.getValue());
             dashboard.setHasCommonFilter(commonFiltersCheckbox.isChecked());
+            dashboard.setLockCommonFilter(lockCfCheckbox.isChecked());
             dashboard.setShowLocalFilter(localFiltersCheckbox.isChecked());
             
             //Removing Common HpccConnection object from session, if Common filters are disabled
@@ -159,6 +163,7 @@ public class DashboardConfigurationController extends SelectorComposer<Component
                 dashboard.setLastupdatedDate(new Timestamp(Calendar.getInstance().getTime().getTime()));
     
                 dashboard.setHasCommonFilter(commonFiltersCheckbox.isChecked());
+                dashboard.setLockCommonFilter(lockCfCheckbox.isChecked());
                 dashboard.setShowLocalFilter(localFiltersCheckbox.isChecked());
                 
                 //Deciding Columns and rows

--- a/src/main/java/org/hpccsystems/dashboard/controller/DashboardController.java
+++ b/src/main/java/org/hpccsystems/dashboard/controller/DashboardController.java
@@ -506,7 +506,7 @@ public class DashboardController extends SelectorComposer<Window>{
             commonInputParams =  new LinkedHashMap<String, Map<String,Set<String>>>();
         }
         for(InputParam globalInput : persistedGlobalInputParams){
-                Set<String> distinctValues = new HashSet<>();
+                Set<String> distinctValues = new LinkedHashSet<>();
                 for(Portlet portlet : dashboard.getPortletList()){
                     if (portlet.getWidgetState().equals( Constants.STATE_LIVE_CHART)
                             && Constants.CATEGORY_TEXT_EDITOR != chartService.getCharts().get(portlet.getChartType()).getCategory()

--- a/src/main/java/org/hpccsystems/dashboard/controller/DashboardController.java
+++ b/src/main/java/org/hpccsystems/dashboard/controller/DashboardController.java
@@ -176,6 +176,8 @@ public class DashboardController extends SelectorComposer<Window>{
     Set<Filter> appliedCommonFilters;
     Set<InputParam> appliedCommonInputParam;
     
+    private List<Button> filterButtons = new ArrayList<Button>();
+    
     Map<String, Set<Field>> commonFields;
     private int drawnLiveChartCount;
     private Map<String, Map<String,Set<String>>>  commonInputParams;
@@ -1040,6 +1042,11 @@ public class DashboardController extends SelectorComposer<Window>{
         button.addEventListener(Events.ON_CLICK, removeGlobalFilter);
         div.appendChild(button);
         
+        filterButtons.add(button);
+        if(dashboard.isLockCommonFilter()) {
+            button.setVisible(false);
+        }
+        
         row.appendChild(div);
         
         Hbox hbox = new Hbox();
@@ -1212,6 +1219,11 @@ public class DashboardController extends SelectorComposer<Window>{
         button.addEventListener(Events.ON_CLICK, removeGlobalFilter);
         div.appendChild(button);
         
+        filterButtons.add(button);
+        if(dashboard.isLockCommonFilter()) {
+            button.setVisible(false);
+        }
+        
         Anchorlayout anchorlayout = new Anchorlayout();
         anchorlayout.setHflex("1");
         
@@ -1364,6 +1376,11 @@ public class DashboardController extends SelectorComposer<Window>{
         button.setStyle("float: right;");
         button.addEventListener(Events.ON_CLICK, removeGlobalFilter);
         div.appendChild(button);
+        
+        filterButtons.add(button);
+        if(dashboard.isLockCommonFilter()) {
+            button.setVisible(false);
+        }
         
         
         // Current implementation assumes, in a dashboard, 
@@ -1622,6 +1639,9 @@ public class DashboardController extends SelectorComposer<Window>{
             
             //Removing the Filter row in UI
             removedRow.detach();
+            
+            //Removing buttons from filter list
+            filterButtons.remove(event.getTarget());
         }
     };
 
@@ -2001,6 +2021,12 @@ public class DashboardController extends SelectorComposer<Window>{
                 Clients.showNotification(Labels.getLabel("unableToUpdateWidget"),
                         Clients.NOTIFICATION_TYPE_ERROR, DashboardController.this.getSelf(), Constants.POSITION_CENTER, 3000, true);
             }
+            
+            if(dashboard.isLockCommonFilter()) {
+                filterButtons.forEach(btn -> btn.setVisible(false));
+            } else {
+                filterButtons.forEach(btn -> btn.setVisible(true));
+            }
         }        
     };
 
@@ -2022,6 +2048,7 @@ public class DashboardController extends SelectorComposer<Window>{
             filterRows.getChildren().clear();
             dashboard.setHasCommonFilter(false);
             
+            filterButtons.clear();
         } catch (Exception e) {
             LOG.debug(" Exception while removing global filters", e);
         }

--- a/src/main/java/org/hpccsystems/dashboard/controller/component/InputListitem.java
+++ b/src/main/java/org/hpccsystems/dashboard/controller/component/InputListitem.java
@@ -1,8 +1,5 @@
 package org.hpccsystems.dashboard.controller.component;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 
 import org.zkoss.zk.ui.Component;
@@ -55,10 +52,7 @@ public class InputListitem extends Listitem {
             listhead.appendChild(listheader);
             popupListbox.appendChild(listhead);
             
-            //Sorting the values of inputparamere
-            List<String> sortedValues = new ArrayList<String>(values);
-            Collections.sort(sortedValues);
-            for (String value : sortedValues) {
+            for (String value : values) {
                 popupListbox.appendChild(new Listitem(value));
             }
             

--- a/src/main/java/org/hpccsystems/dashboard/dao/impl/DashboardDaoImpl.java
+++ b/src/main/java/org/hpccsystems/dashboard/dao/impl/DashboardDaoImpl.java
@@ -168,8 +168,8 @@ public class DashboardDaoImpl implements DashboardDao {
                         dashboard.getVisibility(),
                         dashboard.getHasCommonFilter(),
                         dashboard.showLocalFilter(),
+                        dashboard.isLockCommonFilter(),
                         dashboard.getDashboardId()
-
                 });
     }
 
@@ -339,6 +339,7 @@ public class DashboardDaoImpl implements DashboardDao {
             dashboard.setLastupdatedDate(rs.getTimestamp("last_updated_date"));
             dashboard.setHasCommonFilter(rs.getBoolean("common_filter"));
             dashboard.setShowLocalFilter(rs.getBoolean("show_localfilter"));
+            dashboard.setLockCommonFilter(rs.getBoolean("lock_commonfilter"));
             
             // Only when joining with acl_public table,to get 'role'
             dashboard.setRole(rs.getString("role"));

--- a/src/main/java/org/hpccsystems/dashboard/entity/Dashboard.java
+++ b/src/main/java/org/hpccsystems/dashboard/entity/Dashboard.java
@@ -29,6 +29,7 @@ public class Dashboard {
     private Integer sequence;
     private boolean hasCommonFilter = false;
     private boolean showLocalFilter;
+    private boolean lockCommonFilter;
     private Integer visibility;
     private String role;
   
@@ -352,6 +353,14 @@ public class Dashboard {
 
     public void setShowLocalFilter(boolean showLocalFilter) {
         this.showLocalFilter = showLocalFilter;
+    }
+
+    public boolean isLockCommonFilter() {
+        return lockCommonFilter;
+    }
+
+    public void setLockCommonFilter(boolean lockCommonFilter) {
+        this.lockCommonFilter = lockCommonFilter;
     }
 
 }

--- a/src/main/java/org/hpccsystems/dashboard/rowmapper/DashboardRowMapper.java
+++ b/src/main/java/org/hpccsystems/dashboard/rowmapper/DashboardRowMapper.java
@@ -19,6 +19,7 @@ public class DashboardRowMapper implements RowMapper<Dashboard> {
         dashboard.setVisibility(rs.getInt("visibility"));
         dashboard.setHasCommonFilter(rs.getBoolean("common_filter"));
         dashboard.setShowLocalFilter(rs.getBoolean("show_localfilter"));
+        dashboard.setLockCommonFilter(rs.getBoolean("lock_commonfilter"));
         dashboard.setLastupdatedDate(rs.getTimestamp("last_updated_date"));
         return dashboard;
     }

--- a/src/main/scripts/sql/dashboard.sql
+++ b/src/main/scripts/sql/dashboard.sql
@@ -42,6 +42,7 @@ visibility TINYINT,
 last_updated_date TIMESTAMP,
 common_filter TINYINT,
 show_localfilter TINYINT,
+lock_commonfilter TINYINT,
 filter_order TEXT,
 PRIMARY KEY(dashboard_id)
 ) ENGINE=InnoDB;

--- a/src/main/webapp/demo/css/dashboard.css
+++ b/src/main/webapp/demo/css/dashboard.css
@@ -16,6 +16,11 @@
   	height: 31px;
 }
 
+.radio, .checkbox > input {
+	margin-top: 0;
+    margin-right: 2px;
+}
+
 .radio, .checkbox {
 	margin-top: 0px;
   	margin-bottom: 0px;

--- a/src/main/webapp/demo/js/simpletree.js
+++ b/src/main/webapp/demo/js/simpletree.js
@@ -60,17 +60,6 @@ var reqData = jq.parseJSON(chartData);
         return d.children && d.children.length > 0 ? d.children : null;
     });
 
-
-    // sort the tree according to the node names
-
-    function sortTree() {
-        tree.sort(function(a, b) {
-            return b.name.toLowerCase() < a.name.toLowerCase() ? 1 : -1;
-        });
-    }
-    // Sort the tree initially incase the JSON isn't in a sorted order.
-    sortTree();
-
     // TODO: Pan function, can be better implemented.
 
     function pan(domNode, direction) {
@@ -371,12 +360,18 @@ var reqData = jq.parseJSON(chartData);
             })
             .on('click', click);
 
-        nodeEnter.append("circle")
+        nodeEnter.append("image")
+	    	.attr("xlink:href", function(d) {
+	        	if(!d.imageSrc)
+	        		return d._children ? './chart/icons/circle_c.png' : './chart/icons/circle.png';
+	    		
+	        	return d._children ? './chart/icons/' + d.imageSrc + '_c.png' : './chart/icons/' + d.imageSrc + '.png';
+	    	})
             .attr('class', 'nodeCircle')
-            .attr("r", 0)
-            .style("fill", function(d) {
-                return d._children ? "lightsteelblue" : "#fff";
-            });
+	        .attr("x", -8)
+	        .attr("y", -8)
+	        .attr("width", 16)
+	        .attr("height", 16);
 
         nodeEnter.append("text")
             .attr("x", function(d) {
@@ -418,12 +413,15 @@ var reqData = jq.parseJSON(chartData);
                 return d.name;
             });
 
-        // Change the circle fill depending on whether it has children and is collapsed
-        node.select("circle.nodeCircle")
-            .attr("r", 4.5)
-            .style("fill", function(d) {
-                return d._children ? "lightsteelblue" : "#fff";
-            });
+        // Change the image depending on whether it has children and is collapsed
+        node.select("image.nodeCircle")
+	        .attr("xlink:href", function(d) {
+	        	if(!d.imageSrc) {
+	        		return d._children ? './chart/icons/circle_c.png' : './chart/icons/circle.png';
+	        	}
+	    		
+	        	return d._children ? './chart/icons/' + d.imageSrc + '_c.png' : './chart/icons/' + d.imageSrc + '.png';
+	    	});
 
         // Transition nodes to their new position.
         var nodeUpdate = node.transition()

--- a/src/main/webapp/demo/layout/dashboard_config.zul
+++ b/src/main/webapp/demo/layout/dashboard_config.zul
@@ -52,7 +52,8 @@
 				<div zclass="options-div">
 					<label value="${labels.commonFilters}" zclass="h5"></label>
 				</div>
-				<checkbox zclass="checkbox" id="commonFiltersCheckbox"></checkbox>
+				<checkbox zclass="checkbox" label="Enable" id="commonFiltersCheckbox"></checkbox>
+				<checkbox zclass="checkbox" label="Prevent deletion" id="lockCfCheckbox"></checkbox>
 			</hbox>
 			<hbox align="center" sclass="options-form">
 				<div zclass="options-div">


### PR DESCRIPTION
- Adds node icons for tree chart
- Removed natural sorting from tree nodes. Retains node order provided by the query
- Input parameter values are displayed in the order provided by queries
- Added the ability to hide 'remove' button in common filters

Please modify the DB with

```
ALTER TABLE `dashboard_details`
    ADD COLUMN `lock_commonfilter` TINYINT(4) NULL DEFAULT NULL AFTER `show_localfilter`;
```
