### PR TITLE
Common filter fixes and Permission additions

### DIFF
--- a/src/main/java/org/hpccsystems/dashboard/common/Queries.java
+++ b/src/main/java/org/hpccsystems/dashboard/common/Queries.java
@@ -23,7 +23,7 @@ public class Queries {
     public static final String RETRIEVE_DASHBOARD_DETAILS = "select * from dashboard_details where application_id = ";
     public static final String DASHBOARD_IN_CLAUSE = " and dashboard_id in ";
     public static final String UPDATE_SIDEBAR_DETAILS = "update dashboard_details set sequence=? where dashboard_id=?";
-    public static final String UPDATE_DASHBOARD =  "update dashboard_details set dashboard_name=?,column_count=?,source_id=?,last_updated_date=?,visibility=?,common_filter=?,show_localfilter=?,lock_commonfilter=? where dashboard_id=?";
+    public static final String UPDATE_DASHBOARD =  "update dashboard_details set dashboard_name=?,column_count=?,source_id=?,last_updated_date=?,visibility=?,common_filter=?,show_localfilter=?,lock_commonfilter=?, lock_add_commonfilter=?, lock_charttitle=? where dashboard_id=?";
     public static final String UPDATE_WIDGET_SEQUENCE = "update widget_details set column_identifier=?,widget_sequence=? where widget_id=? and dashboard_id=?";
     public static final String ADD_CHART_DATA = "update widget_details set widget_state=?, chart_type=?  where widget_id=?";
     public static final String CLEAR_CHART_DATA = "update widget_details set widget_name=?, widget_state=?,chart_type=?,chart_data=?  where widget_id=?";
@@ -37,7 +37,8 @@ public class Queries {
     public static final String SELECT_GROUP="select * from acl_public where dashboard_id = ?";
     public static final String DELETE_GROUP="delete from acl_public where dashboard_id=? and group_code in(?)";
     public static final String GET_PRIVATE_DASHBOARDS = "SELECT * FROM dashboard_details WHERE user_id=? AND application_id=? order by sequence";
-    public static final String GET_ROLE_BASED_DASHBOARDS = "SELECT a.role,d.dashboard_id,d.application_id,d.dashboard_name,d.column_count,d.source_id,d.visibility,d.last_updated_date,d.common_filter,d.show_localfilter,d.lock_commonfilter FROM acl_public AS a JOIN dashboard_details AS d ON a.dashboard_id = d.dashboard_id AND a.group_code in ";
+    public static final String GET_ROLE_BASED_DASHBOARDS = "SELECT a.role,d.dashboard_id,d.application_id,d.dashboard_name,d.column_count,d.source_id,d.visibility,d.last_updated_date,d.common_filter,d.show_localfilter,d.lock_commonfilter, d.lock_add_commonfilter, d.lock_charttitle "
+            + "FROM acl_public AS a JOIN dashboard_details AS d ON a.dashboard_id = d.dashboard_id AND a.group_code in ";
     public static final String GET_ALL_DASHBOARD = "SELECT * FROM dashboard_details where application_id=? order by sequence";
     public static final String GET_DASHBOARD = "SELECT * FROM dashboard_details WHERE dashboard_id=?";
     public static final String DELETE_ACL_PUBLIC = "delete from acl_public where dashboard_id=?";

--- a/src/main/java/org/hpccsystems/dashboard/controller/DashboardConfigurationController.java
+++ b/src/main/java/org/hpccsystems/dashboard/controller/DashboardConfigurationController.java
@@ -51,7 +51,13 @@ public class DashboardConfigurationController extends SelectorComposer<Component
     @Wire
     Checkbox lockCfCheckbox;
     @Wire
+    Checkbox lockaddCfCheckbox;
+    @Wire
     Checkbox localFiltersCheckbox;
+    
+    @Wire
+    Checkbox lockTitleCheckbox;
+    
     @Wire
     Hbox commonFilterHbox;
     @Wire
@@ -94,11 +100,16 @@ public class DashboardConfigurationController extends SelectorComposer<Component
             if(dashboard.getHasCommonFilter()){
                 commonFiltersCheckbox.setChecked(true);
                 lockCfCheckbox.setChecked(dashboard.isLockCommonFilter());
+                lockaddCfCheckbox.setChecked(dashboard.isLockaddCommonFilter());
                 isCommonFiltersEnabled = true;
             }
             
             if(dashboard.showLocalFilter()){
                 localFiltersCheckbox.setChecked(true);
+            }
+            
+            if(dashboard.lockChartTitle()){
+                lockTitleCheckbox.setChecked(true);
             }
             
             try {
@@ -141,7 +152,9 @@ public class DashboardConfigurationController extends SelectorComposer<Component
             dashboard.setName(nameTextbox.getValue());
             dashboard.setHasCommonFilter(commonFiltersCheckbox.isChecked());
             dashboard.setLockCommonFilter(lockCfCheckbox.isChecked());
+            dashboard.setLockaddCommonFilter(lockaddCfCheckbox.isChecked());
             dashboard.setShowLocalFilter(localFiltersCheckbox.isChecked());
+            dashboard.setLockChartTitle(lockTitleCheckbox.isChecked());
             
             //Removing Common HpccConnection object from session, if Common filters are disabled
             if(!commonFiltersCheckbox.isChecked()) {
@@ -164,7 +177,9 @@ public class DashboardConfigurationController extends SelectorComposer<Component
     
                 dashboard.setHasCommonFilter(commonFiltersCheckbox.isChecked());
                 dashboard.setLockCommonFilter(lockCfCheckbox.isChecked());
+                dashboard.setLockaddCommonFilter(lockaddCfCheckbox.isChecked());
                 dashboard.setShowLocalFilter(localFiltersCheckbox.isChecked());
+                dashboard.setLockChartTitle(lockTitleCheckbox.isChecked());
                 
                 //Deciding Columns and rows
                 Integer panelCount = null;

--- a/src/main/java/org/hpccsystems/dashboard/controller/DashboardController.java
+++ b/src/main/java/org/hpccsystems/dashboard/controller/DashboardController.java
@@ -170,6 +170,9 @@ public class DashboardController extends SelectorComposer<Window>{
     private Button addWidget;
     
     @Wire
+    private Button addFilterBtn;
+    
+    @Wire
     private Button configureDashboard;
     
     Integer panelCount = 0;
@@ -376,7 +379,11 @@ public class DashboardController extends SelectorComposer<Window>{
                 } else {
                     panel = new ChartPanel(portlet, Constants.SHOW_NO_BUTTONS, dashboard.showLocalFilter());                    
                 }
-                                
+                
+                if(dashboard.lockChartTitle()) {
+                    panel.disableTitleEditing();
+                }
+              
                 portalChildren.get(portlet.getColumn()).appendChild(panel);
                 
                 //Constructing chart data only when live chart is drawn
@@ -435,6 +442,10 @@ public class DashboardController extends SelectorComposer<Window>{
         //Hide Common filters for Consumers
         if(Constants.ROLE_CONSUMER.equals(dashboard.getRole())) {
             commonFiltersPanel.setVisible(false);
+        }
+        
+        if(dashboard.isLockaddCommonFilter()) {
+            addFilterBtn.setVisible(false);
         }
         
         comp.addEventListener("onSidebarResize", sidebarResizeListener);
@@ -1820,7 +1831,7 @@ public class DashboardController extends SelectorComposer<Window>{
             chartPanel = new ChartPanel(portlet,Constants.SHOW_ALL_BUTTONS, dashboard.showLocalFilter());
             portalChildren.get(portlet.getColumn()).appendChild(chartPanel);
             chartPanel.focus();
-            
+                        
             reorderPortletPanels();
             
             widgetService.addWidget(dashboardId, portlet, dashboard.getPortletList().indexOf(portlet));
@@ -2048,6 +2059,27 @@ public class DashboardController extends SelectorComposer<Window>{
                 filterButtons.forEach(btn -> btn.setVisible(false));
             } else {
                 filterButtons.forEach(btn -> btn.setVisible(true));
+            }
+            
+            if(dashboard.getHasCommonFilter() && !dashboard.isLockaddCommonFilter()) {
+                addFilterBtn.setVisible(true);
+            } else if(dashboard.getHasCommonFilter() && dashboard.isLockaddCommonFilter()) {
+                addFilterBtn.setVisible(false);
+            }
+            
+            //Making chart title editable
+            for (Portalchildren component : portalChildren) {
+                component.getChildren()
+                    .stream()
+                    .filter(comp -> comp instanceof ChartPanel)
+                    .forEach(cp -> {
+                        ChartPanel panel = (ChartPanel) cp;
+                        if(dashboard.lockChartTitle()) {
+                            panel.disableTitleEditing();
+                        } else {
+                            panel.enableTitleEditing();
+                        }
+                    });
             }
         }        
     };

--- a/src/main/java/org/hpccsystems/dashboard/controller/DashboardController.java
+++ b/src/main/java/org/hpccsystems/dashboard/controller/DashboardController.java
@@ -1627,26 +1627,30 @@ public class DashboardController extends SelectorComposer<Window>{
             Row removedRow = (Row) event.getTarget().getParent().getParent();
             Boolean rowChecked = (Boolean)removedRow.getAttribute(Constants.ROW_CHECKED);
             
+            Iterator<Portlet> iterator = null;
+            if(Constants.LOGICAL_FILE.equals(dashboard.getFileType())) {
+                iterator = removeFilter(removedRow).iterator();
+                
+                Filter removedFilter = (Filter)removedRow.getAttribute(Constants.FILTER);
+                //Need To remove the filter from applied filter set
+                appliedCommonFilters.remove(removedFilter);
+            } else if(Constants.QUERY.equals(dashboard.getFileType())) {
+                iterator = removeInputparam(removedRow).iterator();
+                
+                String removedInput =  removedRow.getAttribute(Constants.INPUT_PARAM_NAME).toString();
+                InputParam removedInputparam = new InputParam(removedInput);
+                
+                LOG.debug("Available filters - " + appliedCommonInputParam + " Filter to remove - " + removedInputparam);
+                
+                //Need To remove the filter from applied inputparam set
+                appliedCommonInputParam.remove(removedInputparam);
+                if(dashboard.getCommonQueryFilters() != null){
+                    dashboard.getCommonQueryFilters().remove(removedInputparam);
+                }
+            }
+            
             //refresh the portlets, if the removed row/filter has any checked values
             if(rowChecked){
-                Iterator<Portlet> iterator =null;
-                if(Constants.LOGICAL_FILE.equals(dashboard.getFileType())){
-                    iterator = removeFilter(removedRow).iterator();
-                    
-                    Filter removedFilter = (Filter)removedRow.getAttribute(Constants.FILTER);
-                    //Need To remove the filter from applied filter set
-                    appliedCommonFilters.remove(removedFilter);
-                }else if(Constants.QUERY.equals(dashboard.getFileType())){
-                    iterator = removeInputparam(removedRow).iterator();
-                    
-                    String removedInput =  removedRow.getAttribute(Constants.INPUT_PARAM_NAME).toString();
-                    InputParam removedInputparam = new InputParam(removedInput);
-                    //Need To remove the filter from applied inputparam set
-                    appliedCommonInputParam.remove(removedInputparam);
-                    if(dashboard.getCommonQueryFilters() != null){
-                        dashboard.getCommonQueryFilters().remove(removedInputparam);
-                    }
-                }
             
             // refreshing the chart && updating DB
             while (iterator.hasNext()) {

--- a/src/main/java/org/hpccsystems/dashboard/controller/component/ChartPanel.java
+++ b/src/main/java/org/hpccsystems/dashboard/controller/component/ChartPanel.java
@@ -388,6 +388,8 @@ public class ChartPanel extends Panel {
         resizeBtn.setSclass(RESIZE_MAX_STYLE);
         resizeBtn.setTooltiptext("Maximize window");
         
+        titleTextbox.addEventListener(Events.ON_BLUR, titleChangeLisnr);
+        
         if(showLocalFilters) {
             //Shows Input parameters for Quieries(Roxie/Thor)
             onDrawingQueryChart(buttonState);
@@ -396,9 +398,6 @@ public class ChartPanel extends Panel {
         if(Constants.SHOW_ALL_BUTTONS == buttonState) {
         	if(Constants.STATE_EMPTY.equals(portlet.getWidgetState())){
         	    //Adding title change listeners only for ADMINS
-        	    titlelabel.addEventListener(Events.ON_CLICK, enableTitleEdit);
-        	    titleTextbox.addEventListener(Events.ON_BLUR, titleChangeLisnr);
-        	    
         	    addBtn.setTooltiptext("Add Chart");
             }else{
                 addBtn.setTooltiptext("Configure Chart");
@@ -521,7 +520,8 @@ public class ChartPanel extends Panel {
         this.addEventListener("onDrawingQueryChart", event ->{
             onDrawingQueryChart(buttonState);
         });
-        
+     
+        enableTitleEditing();
     }
 
   //Generate dynamic label 'ModelID:<$A030>'
@@ -1315,5 +1315,13 @@ public class ChartPanel extends Panel {
         if(inputParamBtn != null){
             inputParamBtn.setVisible(false);
         }
+    }
+    
+    public void enableTitleEditing() {
+        titlelabel.addEventListener(Events.ON_CLICK, enableTitleEdit);
+    }
+    
+    public void disableTitleEditing() {
+        titlelabel.removeEventListener(Events.ON_CLICK, enableTitleEdit);
     }
 } 

--- a/src/main/java/org/hpccsystems/dashboard/dao/impl/DashboardDaoImpl.java
+++ b/src/main/java/org/hpccsystems/dashboard/dao/impl/DashboardDaoImpl.java
@@ -102,6 +102,7 @@ public class DashboardDaoImpl implements DashboardDao {
         parameters.put("visibility", dashboard.getVisibility());
         parameters.put("common_filter", dashboard.getHasCommonFilter());
         parameters.put("show_localfilter", dashboard.showLocalFilter());
+        parameters.put("lock_charttitle", dashboard.lockChartTitle());
         
         Number newId = new SimpleJdbcInsert(jdbcTemplate.getDataSource())
                         .withTableName("dashboard_details")
@@ -169,6 +170,8 @@ public class DashboardDaoImpl implements DashboardDao {
                         dashboard.getHasCommonFilter(),
                         dashboard.showLocalFilter(),
                         dashboard.isLockCommonFilter(),
+                        dashboard.isLockaddCommonFilter(),
+                        dashboard.lockChartTitle(),
                         dashboard.getDashboardId()
                 });
     }
@@ -339,6 +342,8 @@ public class DashboardDaoImpl implements DashboardDao {
             dashboard.setLastupdatedDate(rs.getTimestamp("last_updated_date"));
             dashboard.setHasCommonFilter(rs.getBoolean("common_filter"));
             dashboard.setShowLocalFilter(rs.getBoolean("show_localfilter"));
+            dashboard.setLockaddCommonFilter(rs.getBoolean("lock_add_commonfilter"));
+            dashboard.setLockChartTitle(rs.getBoolean("lock_charttitle"));
             dashboard.setLockCommonFilter(rs.getBoolean("lock_commonfilter"));
             
             // Only when joining with acl_public table,to get 'role'

--- a/src/main/java/org/hpccsystems/dashboard/entity/Dashboard.java
+++ b/src/main/java/org/hpccsystems/dashboard/entity/Dashboard.java
@@ -30,6 +30,8 @@ public class Dashboard {
     private boolean hasCommonFilter = false;
     private boolean showLocalFilter;
     private boolean lockCommonFilter;
+    private boolean lockaddCommonFilter;
+    private boolean lockChartTitle;
     private Integer visibility;
     private String role;
   
@@ -361,6 +363,22 @@ public class Dashboard {
 
     public void setLockCommonFilter(boolean lockCommonFilter) {
         this.lockCommonFilter = lockCommonFilter;
+    }
+
+    public boolean isLockaddCommonFilter() {
+        return lockaddCommonFilter;
+    }
+
+    public void setLockaddCommonFilter(boolean lockaddCommonFilter) {
+        this.lockaddCommonFilter = lockaddCommonFilter;
+    }
+
+    public boolean lockChartTitle() {
+        return lockChartTitle;
+    }
+
+    public void setLockChartTitle(boolean lockChartTitle) {
+        this.lockChartTitle = lockChartTitle;
     }
 
 }

--- a/src/main/java/org/hpccsystems/dashboard/rowmapper/DashboardRowMapper.java
+++ b/src/main/java/org/hpccsystems/dashboard/rowmapper/DashboardRowMapper.java
@@ -20,6 +20,8 @@ public class DashboardRowMapper implements RowMapper<Dashboard> {
         dashboard.setHasCommonFilter(rs.getBoolean("common_filter"));
         dashboard.setShowLocalFilter(rs.getBoolean("show_localfilter"));
         dashboard.setLockCommonFilter(rs.getBoolean("lock_commonfilter"));
+        dashboard.setLockaddCommonFilter(rs.getBoolean("lock_add_commonfilter"));
+        dashboard.setLockChartTitle(rs.getBoolean("lock_charttitle"));
         dashboard.setLastupdatedDate(rs.getTimestamp("last_updated_date"));
         return dashboard;
     }

--- a/src/main/scripts/sql/dashboard.sql
+++ b/src/main/scripts/sql/dashboard.sql
@@ -43,6 +43,8 @@ last_updated_date TIMESTAMP,
 common_filter TINYINT,
 show_localfilter TINYINT,
 lock_commonfilter TINYINT,
+lock_add_commonfilter TINYINT,
+lock_charttitle TINYINT,
 filter_order TEXT,
 PRIMARY KEY(dashboard_id)
 ) ENGINE=InnoDB;

--- a/src/main/webapp/demo/layout/dashboard.zul
+++ b/src/main/webapp/demo/layout/dashboard.zul
@@ -88,7 +88,8 @@
 								<tabpanels>	</tabpanels>
 							</tabbox>
 						</popup>
-						<button sclass="glyphicon glyphicon-plus btn btn-link img-btn" popup="filterColumnPopup, position=start_before"></button>
+						<button style="    visibility: hidden;"></button>
+						<button id="addFilterBtn" sclass="glyphicon glyphicon-plus btn btn-link img-btn" popup="filterColumnPopup, position=start_before"></button>
 					</toolbar>
 				</hbox>
 			</div>

--- a/src/main/webapp/demo/layout/dashboard_config.zul
+++ b/src/main/webapp/demo/layout/dashboard_config.zul
@@ -36,6 +36,11 @@
 		.options-div {
 			width: 150px
 		}
+		
+		input[type="radio"]:focus {
+			outline: none;
+    		box-shadow: none;
+		}
 </style>
 	
 	<vbox spacing="0px" hflex="1">		
@@ -45,22 +50,32 @@
 			<textbox id="nameTextbox"  zclass="form-control"></textbox>
 		</hlayout>
 	
-		<hlayout zclass="form-group">
+		<vlayout spacing="10px" zclass="form-group">
 			<label zclass="label" value="${labels.dashboardOptions}"></label>
 			
 			<hbox id ="commonFilterHbox" align="center" sclass="options-form" visible="false">
 				<div zclass="options-div">
 					<label value="${labels.commonFilters}" zclass="h5"></label>
 				</div>
-				<checkbox zclass="checkbox" label="Enable" id="commonFiltersCheckbox"></checkbox>
+				<checkbox label="Enable" id="commonFiltersCheckbox"></checkbox>
 				<space></space>
-				<checkbox zclass="checkbox" label="Prevent deletion" id="lockCfCheckbox"></checkbox>
+				<checkbox label="Prevent deletion" id="lockCfCheckbox"></checkbox>
+				<space></space>
+				<checkbox label="Prevent Addition" id="lockaddCfCheckbox"></checkbox>
 			</hbox>
+			
 			<hbox align="center" sclass="options-form">
 				<div zclass="options-div">
-					<label value="Show local filters" zclass="h5"></label>
+					<label value="Chart Titles" zclass="h5"></label>
 				</div>
-				<checkbox zclass="checkbox" id="localFiltersCheckbox"></checkbox>
+				<checkbox id="lockTitleCheckbox" label="Disable title modification"></checkbox>
+			</hbox>
+			
+			<hbox align="center" sclass="options-form">
+				<div zclass="options-div">
+					<label value="Widget level filters" zclass="h5"></label>
+				</div>
+				<checkbox id="localFiltersCheckbox" label="Show filter popup"></checkbox>
 			</hbox>
 			
 			<hbox align="center" sclass="options-form">
@@ -68,11 +83,12 @@
 					<label value="Dashboard Visiblity" zclass="h5"></label>
 				</div>
 				<radiogroup id="visiblityRadiogroup">
-					<radio  zclass="radio-inline" value="0" label="Private" selected="true"></radio>
-					<radio  zclass="radio-inline" value="1" label="Public"></radio>
+					<radio  value="0" label="Private" selected="true"></radio>
+					<space></space>
+					<radio  value="1" label="Public"></radio>
 				</radiogroup>
 			</hbox>
-		</hlayout>
+		</vlayout>
 		
 		<hlayout id="layout" zclass="form-group">
 			<label zclass="label" value="${labels.dashboardLayout}"></label>


### PR DESCRIPTION
- Fixed common filter issues
- Adds permission checks to Chart tile editing and Adding new common filters

DB Script

```
ALTER TABLE `dashboard_details`
    ADD COLUMN `lock_add_commonfilter` TINYINT(4) NULL DEFAULT NULL AFTER `lock_commonfilter`,
    ADD COLUMN `lock_charttitle` TINYINT(4) NULL DEFAULT NULL AFTER `lock_add_commonfilter`;
```
